### PR TITLE
fix: Dependency versions following new roles tag

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,27 +1,21 @@
 ---
-# Ansible Requirements
-# TODO: Update version attributes to match MAJOR.MINOR.PATCH version (i.e. the git tag) of the roles,
-#       once available. Note that pinning down to the PATCH number in the `version` attribute while
-#       referencing only the MINOR version in the role name translates to Ansible Playbooks automatically
-#       import the latest fixes for Ansible Roles they depend on, assuming older versions of said Ansible
-#       Roles are not cached locally, in the `./roles` or `~/.ansible/roles` directories for example.
 roles:
   - name: ewc-ansible-role-update-system-1.0
     src: https://github.com/ewcloud/ewc-ansible-role-update-system.git
-    version: main
+    version: 1.0.0
 
   - name: ewc-ansible-role-mars-client-1.0
     src: https://github.com/ewcloud/ewc-ansible-role-mars-client.git
-    version: main
+    version: 1.0.1
 
-  - name: ewc-ansible-role-conda-1.0
+  - name: ewc-ansible-role-conda-1.1
     src: https://github.com/ewcloud/ewc-ansible-role-conda.git
-    version: main
+    version: 1.1.0
 
   - name: ewc-ansible-role-ecmwf-toolbox-1.0
     src: https://github.com/ewcloud/ewc-ansible-role-ecmwf-toolbox.git
-    version: main
+    version: 1.0.1
 
   - name: ewc-ansible-role-jupyterhub-local-1.0
     src: https://github.com/ewcloud/ewc-ansible-role-jupyterhub-local.git
-    version: main
+    version: 1.0.1


### PR DESCRIPTION
Hello @xavierabellan,

In the `requirements.yml`, there was an unattended TODO, left  on Aug. 12th  (before the different Ansible Roles had a valid git tag assigned to them). It should be now addressed, after the round of releases you performed on Sep. 11th:

https://github.com/ewcloud/ewc-flavours/blob/0a995871d3bb293cac720485a7b243637559e3e2/requirements.yml#L3-L7

**IMPORTANT**: Currently, the `jupyterhub-flavour` is likely to fail without manual installation of both `ewc-ansible-role-conda-1.0` and `ewc-ansible-role-conda-1.1` 