### PR TITLE
ci: Upload run artifacts even if test stage exists with error

### DIFF
--- a/.github/workflows/test-ecmwf.yml
+++ b/.github/workflows/test-ecmwf.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: Upload test deployment result
         uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: artifacts_${{ github.run_id }}
           path: ${{ steps.test-deployment.outputs.artifactPath }}

--- a/.github/workflows/test-eumetsat.yml
+++ b/.github/workflows/test-eumetsat.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: Upload test deployment results
         uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: artifacts_${{ github.run_id }}
           path: ${{ steps.test-deployment.outputs.artifactPath }}


### PR DESCRIPTION
Hi @slanglois,

A minor change to ensure artifacts containing machine-friendly data on tests are available even when the test deployment job step fails.